### PR TITLE
refactor ratings calculations in route for all spots

### DIFF
--- a/backend/routes/api/spot-images.js
+++ b/backend/routes/api/spot-images.js
@@ -25,7 +25,7 @@ router.delete('/:imageId', requireAuth, async (req, res, next) => {
   
   // Check if the image exists, and throw an error if not
   if (!image) {
-    const error = new Error('Image not found');
+    const error = new Error('The image you are trying to delete could not be found');
     error.status = 404;
     error.title = 'Image not found';
     
@@ -46,7 +46,7 @@ router.delete('/:imageId', requireAuth, async (req, res, next) => {
   // Else, delete the image
   await image.destroy();
   return res.json({
-    "message": "Successfully deleted",
+    "message": "Image successfully deleted",
     "statusCode": 200
   })
 })


### PR DESCRIPTION
- Original logic for displaying aggregate review scores involved iterating through every review in the database for each spot, leading to O(n2) time complexity.  Although the ideal is to have sequelize perform this calculation, for now this has been refactored to only check the reviews associated with each spot, improving complexity to O(n * m) where m represents the number of reviews for each spot.